### PR TITLE
Add option to set IAM role for authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.amazonsqs</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
     <name>WSO2 Carbon - Mediation Library Connector For amazonsqs</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/auth/AmazonSQSContext.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/auth/AmazonSQSContext.java
@@ -54,7 +54,7 @@ public class AmazonSQSContext extends AbstractConnector {
                     && !(key).toString().startsWith(AmazonSQSConstants.SIGNATURE_VERSION) && !(key).toString().startsWith(AmazonSQSConstants.SIGNATURE_METHOD)
                     && !(key).toString().startsWith(AmazonSQSConstants.VERSION) && !(key).toString().startsWith(AmazonSQSConstants.TERMINATION_STRING)
                     && !(key).toString().startsWith(AmazonSQSConstants.REGION) && !(key).toString().startsWith(AmazonSQSConstants.HOST)
-                    && !(key).toString().startsWith(AmazonSQSConstants.HTTP_METHOD)) {
+                    && !(key).toString().startsWith(AmazonSQSConstants.HTTP_METHOD) && !(key).toString().startsWith(AmazonSQSConstants.SECURITY_TOKEN)) {
                 messageContext.getPropertyKeySet().remove(key);
             }
         }

--- a/src/main/resources/amazonSQS-config/init.xml
+++ b/src/main/resources/amazonSQS-config/init.xml
@@ -20,6 +20,8 @@
     <parameter name="accessKeyId"
                description="The access key ID that corresponds to the secret access key that you used to sign the request"/>
     <parameter name="secretAccessKey" description="The secretAccessKey"/>
+    <parameter name="iamRole" description="The IAM role associated with the instance"/>
+    <parameter name="enableIMDSv1" description="Use IMDSv1 to access instance metadata"/>
     <parameter name="version" description="The API version that the request is written for"/>
     <parameter name="region" description="Region which is used select a regional endpoint to make requests"/>
     <parameter name="enableSSL" description="This uses the enabling https amazon aws URL"/>
@@ -30,6 +32,8 @@
     <sequence>
         <property name="uri.var.accessKeyId" expression="$func:accessKeyId"/>
         <property name="uri.var.secretAccessKey" expression="$func:secretAccessKey"/>
+        <property name="uri.var.iamRole" expression="$func:iamRole"/>
+        <property name="uri.var.enableIMDSv1" expression="$func:enableIMDSv1"/>
         <property name="uri.var.version" expression="$func:version"/>
         <property name="uri.var.region" expression="$func:region"/>
         <property name="uri.var.enableSSL" expression="$func:enableSSL"/>
@@ -71,6 +75,70 @@
                     </else>
                 </filter>
             </else>
+        </filter>
+        <!-- If IAM role is defined, call the EC2 metadata endpoints and get the AccessKeyId, SecretAccessKey and
+        SecurityToken. -->
+        <filter xpath="not(get-property('uri.var.iamRole') = '') and string(get-property('uri.var.iamRole'))">
+            <then>
+                <property name="REST_URL_POSTFIX" scope="axis2" action="remove"/>
+                <!-- By default IMDSv2 will be used to query instance metadata. -->
+                <filter xpath="not(get-property('uri.var.enableIMDSv1') = 'true')">
+                    <then>
+                        <property name="uri.var.tokenUri" value="http://169.254.169.254/latest/api/token"/>
+                        <header name="X-aws-ec2-metadata-token-ttl-seconds"
+                                scope="transport"
+                                value="21600"/>
+                        <filter source="$ctx:amazonSQSBlocking" regex="true">
+                            <then>
+                                <call blocking="true">
+                                    <endpoint>
+                                        <http method="PUT" uri-template="{uri.var.tokenUri}"/>
+                                    </endpoint>
+                                </call>
+                            </then>
+                            <else>
+                                <call>
+                                    <endpoint>
+                                        <http method="PUT" uri-template="{uri.var.tokenUri}"/>
+                                    </endpoint>
+                                </call>
+                            </else>
+                        </filter>
+                        <!-- AWS EC2 metadata endpoint always use the text/plain as content type. Therefore we need
+                        to get the text element from the body.
+                         -->
+                        <header name="X-aws-ec2-metadata-token" scope="transport" expression="json-eval($.text)"/>
+                        <header name="X-aws-ec2-metadata-token-ttl-seconds" scope="transport" action="remove"/>
+                    </then>
+                </filter>
+                <property name="uri.var.securityCredentialsUri"
+                          expression="fn:concat('http://169.254.169.254/latest/meta-data/iam/security-credentials/', get-property('uri.var.iamRole'))"/>
+                <filter source="$ctx:amazonSQSBlocking" regex="true">
+                    <then>
+                        <call blocking="true">
+                            <endpoint>
+                                <http method="GET" uri-template="{uri.var.securityCredentialsUri}"/>
+                            </endpoint>
+                        </call>
+                    </then>
+                    <else>
+                        <call>
+                            <endpoint>
+                                <http method="GET" uri-template="{uri.var.securityCredentialsUri}"/>
+                            </endpoint>
+                        </call>
+                    </else>
+                </filter>
+                <header name="X-aws-ec2-metadata-token" scope="transport" action="remove"/>
+                <property name="bodyJson" expression="json-eval($.text)"/>
+                <enrich>
+                    <source clone="false" xpath="$ctx:bodyJson"/>
+                    <target type="body"/>
+                </enrich>
+                <property name="uri.var.accessKeyId" expression="json-eval($.AccessKeyId)"/>
+                <property name="uri.var.secretAccessKey" expression="json-eval($.SecretAccessKey)"/>
+                <property name="uri.var.securityToken" expression="json-eval($.Token)"/>
+            </then>
         </filter>
         <property name="REQUEST_HOST_HEADER" scope="axis2" expression="$ctx:uri.var.hostName"/>
     </sequence>

--- a/src/main/resources/uischema/connection.json
+++ b/src/main/resources/uischema/connection.json
@@ -33,7 +33,7 @@
                     "displayName": "Access Key ID",
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
-                    "required": "true",
+                    "required": "false",
                     "helpTip": "The access key ID that corresponds to the secret access key that you used to sign the request."
                   }
                 },
@@ -44,8 +44,30 @@
                     "displayName": "Secret Access Key",
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
-                    "required": "true",
+                    "required": "false",
                     "helpTip": "AWS secret access key."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "iamRole",
+                    "displayName": "IAM role",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The IAM role associated with the instance."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "enableIMDSv1",
+                    "displayName": "Enable IMDSv1",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Use IMDSv1 to access instance metadata."
                   }
                 },
                 {


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2-extensions/esb-connector-amazonsqs/issues/24

## Goals
Add option to set IAM role for authentication.

## User stories

When the EI server is running in an EC2 instance, the user can set the IAM role for authentication. By default IMDSv2 is used to retrieve instance meta data. To use IMDSv1, you need to explicitly set `enableIMDSv1` to true in the amazonsqs init operation.

A sample init configuration is shown below,

```xml
<amazonsqs.init>
        <connectionType>amazonsqs</connectionType>
        <version>2009-02-01</version>
        <iamRole>ei_connector_sample_role</iamRole>
        <enableSSL>false</enableSSL>
        <blocking>false</blocking>
        <name>AMAZON_SQS_CONNECTION_1</name>
        <region>us-east-2</region>
 </amazonsqs.init>
```