### PR TITLE
Make IAM authentication backward compatible.

### DIFF
--- a/src/main/resources/amazonSQS-config/init.xml
+++ b/src/main/resources/amazonSQS-config/init.xml
@@ -107,7 +107,8 @@
                         <!-- AWS EC2 metadata endpoint always use the text/plain as content type. Therefore we need
                         to get the text element from the body.
                          -->
-                        <header name="X-aws-ec2-metadata-token" scope="transport" expression="json-eval($.text)"/>
+                        <property name="bodyJson" expression="json-eval($.text)"/>
+                        <header name="X-aws-ec2-metadata-token" scope="transport" expression="get-property('bodyJson')"/>
                         <header name="X-aws-ec2-metadata-token-ttl-seconds" scope="transport" action="remove"/>
                     </then>
                 </filter>


### PR DESCRIPTION
## Purpose
> Since the header mediator does not have the native JSON support in previous EI version connector deployment leads to issue.
> We have ported the JSON support for header mediator to EI-6.5.0. 
> This PR addresses the issue at the connector level (In case more versions are effected).
Fixes: https://github.com/wso2/product-ei/issues/5521