### PR TITLE
Set FORCE_POST_PUT_NOBODY property to true in init operation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.amazonsqs</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <name>WSO2 Carbon - Mediation Library Connector For amazonsqs</name>
     <url>http://wso2.org</url>
     <properties>
@@ -223,7 +223,7 @@
                         <id>email-library</id>
                         <phase>compile</phase>
                         <goals>
-                            <goal>attached</goal>
+                            <goal>single</goal>
                         </goals>
                         <configuration>
                             <finalName>${connector.name}-connector-${version}</finalName>
@@ -376,7 +376,7 @@
         <repository>
             <id>wso2-nexus</id>
             <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/groups/wso2-public/</url>
+            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -386,7 +386,7 @@
         <repository>
             <id>wso2.releases</id>
             <name>WSO2 internal Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/releases/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
             <releases>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -396,7 +396,7 @@
         <repository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
             <snapshots>
                 <enabled>true</enabled>
                 <updatePolicy>daily</updatePolicy>
@@ -410,12 +410,12 @@
         <repository>
             <id>nexus-releases</id>
             <name>WSO2 Release Distribution Repository</name>
-            <url>http://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
+            <url>https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/</url>
         </repository>
         <snapshotRepository>
             <id>wso2.snapshots</id>
             <name>Apache Snapshot Repository</name>
-            <url>http://maven.wso2.org/nexus/content/repositories/snapshots/</url>
+            <url>https://maven.wso2.org/nexus/content/repositories/snapshots/</url>
         </snapshotRepository>
     </distributionManagement>
 </project>

--- a/src/main/assembly/assemble-connector.xml
+++ b/src/main/assembly/assemble-connector.xml
@@ -17,6 +17,7 @@
  ~  under the License.
 -->
 <assembly>
+    <id>connector</id>
     <formats>
         <format>zip</format>
     </formats>

--- a/src/main/resources/amazonSQS-config/init.xml
+++ b/src/main/resources/amazonSQS-config/init.xml
@@ -85,6 +85,7 @@
                 <filter xpath="not(get-property('uri.var.enableIMDSv1') = 'true')">
                     <then>
                         <property name="uri.var.tokenUri" value="http://169.254.169.254/latest/api/token"/>
+                        <property name="FORCE_POST_PUT_NOBODY" value="true" scope="axis2" type="BOOLEAN"/>
                         <header name="X-aws-ec2-metadata-token-ttl-seconds"
                                 scope="transport"
                                 value="21600"/>


### PR DESCRIPTION
## Purpose
In MI versions the above property is set to true by default. In EI version we need to explicitly set it to avoid the init flow getting hanged when calling the token endpoint.

Fixes: https://github.com/wso2/micro-integrator/issues/3148