### PR TITLE
Double escape new line characters within JSON values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.amazonsqs</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.3</version>
+    <version>1.1.4</version>
     <name>WSO2 Carbon - Mediation Library Connector For amazonsqs</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/auth/AmazonSQSAuthConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/auth/AmazonSQSAuthConnector.java
@@ -138,8 +138,14 @@ public class AmazonSQSAuthConnector extends AbstractConnector {
                 payloadStrBuilder.append('"');
                 payloadStrBuilder.append(AmazonSQSConstants.COLON);
                 payloadStrBuilder.append('"');
-                payloadStrBuilder.append(entry.getValue().replace(System.lineSeparator(),"").
-                        replace("\"", "\\\"").replace("\\\\\"", "\\\""));
+                if (entry.getKey().equals(AmazonSQSConstants.API_MESSAGE_BODY)
+                        && AmazonSQSConstants.JSON_START_CHARACTER.contains(entry.getValue().substring(0, 1))) {
+                    payloadStrBuilder.append(entry.getValue().replace(System.lineSeparator(), "").
+                            replace("\"", "\\\"").replace("\\\\\"", "\\\"").replaceAll("(?<!\\\\)\\\\n", "\\\\\\\\n"));
+                } else {
+                    payloadStrBuilder.append(entry.getValue().replace(System.lineSeparator(), "").
+                            replace("\"", "\\\"").replace("\\\\\"", "\\\""));
+                }
                 payloadStrBuilder.append('"');
                 payloadStrBuilder.append(AmazonSQSConstants.COMMA);
             }
@@ -261,7 +267,7 @@ public class AmazonSQSAuthConnector extends AbstractConnector {
         jsonBuilder.append(AmazonSQSConstants.COLON);
         jsonBuilder.append('"');
         jsonBuilder.append(entry.getValue().replace(System.lineSeparator(),"").
-                replace("\"", "\\\"").replace("\\\\\"", "\\\""));
+                replace("\"", "\\\"").replace("\\\\\"", "\\\"").replaceAll("(?<!\\\\)\\\\n", "\\\\\\\\n"));
         jsonBuilder.append('"');
         jsonBuilder.append(AmazonSQSConstants.COMMA);
         String jsonStr = "{" + jsonBuilder.substring(0, jsonBuilder.length() - 1) + "}";


### PR DESCRIPTION
## Purpose
Since we send out the SQS message as x-www-form-urlencoded, we need to double escape the new line characters within JSON values so that the formatter sends out the escaped new line character.

Fixes https://github.com/wso2/micro-integrator/issues/3285