### PR TITLE
Double escape special characters within JSON values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.amazonsqs</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.5</version>
+    <version>1.1.6</version>
     <name>WSO2 Carbon - Mediation Library Connector For amazonsqs</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/auth/AmazonSQSAuthConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/auth/AmazonSQSAuthConnector.java
@@ -142,7 +142,9 @@ public class AmazonSQSAuthConnector extends AbstractConnector {
                         && AmazonSQSConstants.JSON_START_CHARACTER.contains(entry.getValue().trim().substring(0, 1))) {
                     payloadStrBuilder.append(entry.getValue().replace(System.lineSeparator(), "").
                             replaceAll("(?<!\\\\)\\\\\"", "\\\\\\\\\\\\\"").replace("\"", "\\\"").
-                            replace("\\\\\"", "\\\"").replaceAll("(?<!\\\\)\\\\n", "\\\\\\\\n"));
+                            replace("\\\\\"", "\\\"").replaceAll("(?<!\\\\)\\\\n", "\\\\\\\\n")
+                            .replaceAll("(?<!\\\\)\\\\t", "\\\\\\\\t").replaceAll("(?<!\\\\)\\\\b", "\\\\\\\\b")
+                            .replaceAll("(?<!\\\\)\\\\f", "\\\\\\\\f").replaceAll("(?<!\\\\)\\\\r", "\\\\\\\\r"));
                 } else {
                     payloadStrBuilder.append(entry.getValue().replace(System.lineSeparator(), "").
                             replace("\"", "\\\"").replace("\\\\\"", "\\\""));
@@ -269,7 +271,9 @@ public class AmazonSQSAuthConnector extends AbstractConnector {
         jsonBuilder.append('"');
         jsonBuilder.append(entry.getValue().replace(System.lineSeparator(),"").
                 replaceAll("(?<!\\\\)\\\\\"", "\\\\\\\\\\\\\"").replace("\"", "\\\"").
-                replace("\\\\\"", "\\\"").replaceAll("(?<!\\\\)\\\\n", "\\\\\\\\n"));
+                replace("\\\\\"", "\\\"").replaceAll("(?<!\\\\)\\\\n", "\\\\\\\\n")
+                .replaceAll("(?<!\\\\)\\\\t", "\\\\\\\\t").replaceAll("(?<!\\\\)\\\\b", "\\\\\\\\b")
+                .replaceAll("(?<!\\\\)\\\\f", "\\\\\\\\f").replaceAll("(?<!\\\\)\\\\r", "\\\\\\\\r"));
         jsonBuilder.append('"');
         jsonBuilder.append(AmazonSQSConstants.COMMA);
         String jsonStr = "{" + jsonBuilder.substring(0, jsonBuilder.length() - 1) + "}";


### PR DESCRIPTION
## Purpose
Since we send out the SQS message as `x-www-form-urlencoded`, we need to double escape the special characters within JSON values so that the formatter sends out the escaped special character.

Fixes: https://github.com/wso2/micro-integrator/issues/3375