### PR TITLE
[PATCH] Add changes to support providing time configs in milliseconds

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -12,7 +12,7 @@
     ],
     "releases": [
         {
-            "tagName": "v2.0.0",
+            "tagName": "v2.0.1",
             "products": [
                 "MI 4.3.0",
                 "MI 4.2.0",

--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ The Amazon SQS connector allows you to access the exposed API through the WSO2 E
 
 ## Compatibility
 
-| Connector version | Supported WSO2 ESB/EI version |
-| ------------- |------------- |
+| Connector version                                                                                                  | Supported WSO2 ESB/EI version |
+|--------------------------------------------------------------------------------------------------------------------|------------- |
+| [2.0.1](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/v2.0.1)                                    | MI 4.3.0                                         |
 | [2.0.0](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/v2.0.0)                                    | MI 4.3.0                                         |
-|  [1.1.0](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/v1.1.0)        |  EI 7.0.x, EI 6.6.0, EI 6.4.0, EI 6.3.0, EI 6.1.1 |
-|  [1.0.8](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/v1.0.8)        |  EI 7.0.x, EI 6.6.0, EI 6.4.0, EI 6.3.0, EI 6.1.1 |
-|  [1.0.7](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/org.wso2.carbon.connector.amazonsqs-1.0.7)        |  EI 7.0.x, EI 6.6.0, EI 6.4.0, EI 6.3.0, EI 6.1.1 |
-|  [1.0.6](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/org.wso2.carbon.connector.amazonsqs-1.0.6)        |  EI 6.4.0, EI 6.3.0, EI 6.1.1 |
-|  [1.0.5](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/org.wso2.carbon.connector.amazonsqs-1.0.5)        |  EI 6.1.1, ESB 5.0.0, ESB 4.9.0 |
+| [1.1.0](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/v1.1.0)                                    |  EI 7.0.x, EI 6.6.0, EI 6.4.0, EI 6.3.0, EI 6.1.1 |
+| [1.0.8](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/v1.0.8)                                    |  EI 7.0.x, EI 6.6.0, EI 6.4.0, EI 6.3.0, EI 6.1.1 |
+| [1.0.7](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/org.wso2.carbon.connector.amazonsqs-1.0.7) |  EI 7.0.x, EI 6.6.0, EI 6.4.0, EI 6.3.0, EI 6.1.1 |
+| [1.0.6](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/org.wso2.carbon.connector.amazonsqs-1.0.6) |  EI 6.4.0, EI 6.3.0, EI 6.1.1 |
+| [1.0.5](https://github.com/wso2-extensions/esb-connector-amazonsqs/tree/org.wso2.carbon.connector.amazonsqs-1.0.5) |  EI 6.1.1, ESB 5.0.0, ESB 4.9.0 |
 
 ## Documentation
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.amazonsqs</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <name>WSO2 Carbon - Mediation Library Connector For amazonsqs</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/config/Init.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/config/Init.java
@@ -101,25 +101,25 @@ public class Init extends AbstractConnector implements ManagedLifecycle {
         connectionConfig.setAwsAccessKeyId(awsAccessKeyId);
         connectionConfig.setAwsSecretAccessKey(awsSecretAccessKey);
         if (StringUtils.isNotBlank(socketTimeout)) {
-            connectionConfig.setSocketTimeout(Integer.valueOf(socketTimeout));
+            connectionConfig.setSocketTimeout(Utils.convertToMillis(socketTimeout));
         }
         if (StringUtils.isNotBlank(connectionTimeout)) {
-            connectionConfig.setConnectionTimeout(Integer.valueOf(connectionTimeout));
+            connectionConfig.setConnectionTimeout(Utils.convertToMillis(connectionTimeout));
         }
         if (StringUtils.isNotBlank(connectionMaxIdleTime)) {
-            connectionConfig.setConnectionMaxIdleTime(Integer.valueOf(connectionMaxIdleTime));
+            connectionConfig.setConnectionMaxIdleTime(Utils.convertToMillis(connectionMaxIdleTime));
         }
         if (StringUtils.isNotBlank(connectionTimeToLive)) {
-            connectionConfig.setConnectionTimeToLive(Integer.valueOf(connectionTimeToLive));
+            connectionConfig.setConnectionTimeToLive(Utils.convertToMillis(connectionTimeToLive));
         }
         if (StringUtils.isNotBlank(connectionAcquisitionTimeout)) {
-            connectionConfig.setConnectionAcquisitionTimeout(Integer.valueOf(connectionAcquisitionTimeout));
+            connectionConfig.setConnectionAcquisitionTimeout(Utils.convertToMillis(connectionAcquisitionTimeout));
         }
         if (StringUtils.isNotBlank(apiCallTimeout)) {
-            connectionConfig.setApiCallTimeout(Integer.valueOf(apiCallTimeout));
+            connectionConfig.setApiCallTimeout(Utils.convertToMillis(apiCallTimeout));
         }
         if (StringUtils.isNotBlank(apiCallAttemptTimeout)) {
-            connectionConfig.setApiCallAttemptTimeout(Integer.valueOf(apiCallAttemptTimeout));
+            connectionConfig.setApiCallAttemptTimeout(Utils.convertToMillis(apiCallAttemptTimeout));
         }
         return connectionConfig;
     }

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/connection/SqsConnection.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/connection/SqsConnection.java
@@ -74,19 +74,19 @@ public class SqsConnection implements Connection {
         Integer apiCallAttemptTimeout = connectionConfig.getApiCallAttemptTimeout();
         ApacheHttpClient.Builder apacheHttpClientBuilder = ApacheHttpClient.builder();
         if (connectionTimeout != -1) {
-            apacheHttpClientBuilder.connectionTimeout(Duration.ofSeconds(connectionTimeout));
+            apacheHttpClientBuilder.connectionTimeout(Duration.ofMillis(connectionTimeout));
         }
         if (connectionAcquisitionTimeout != -1) {
-            apacheHttpClientBuilder.connectionAcquisitionTimeout(Duration.ofSeconds(connectionAcquisitionTimeout));
+            apacheHttpClientBuilder.connectionAcquisitionTimeout(Duration.ofMillis(connectionAcquisitionTimeout));
         }
         if (socketTimeout != -1) {
-            apacheHttpClientBuilder.socketTimeout(Duration.ofSeconds(socketTimeout));
+            apacheHttpClientBuilder.socketTimeout(Duration.ofMillis(socketTimeout));
         }
         if (connectionTimeToLive != -1) {
-            apacheHttpClientBuilder.connectionTimeToLive(Duration.ofSeconds(connectionTimeToLive));
+            apacheHttpClientBuilder.connectionTimeToLive(Duration.ofMillis(connectionTimeToLive));
         }
         if (connectionMaxIdleTime != -1) {
-            apacheHttpClientBuilder.connectionMaxIdleTime(Duration.ofSeconds(connectionMaxIdleTime));
+            apacheHttpClientBuilder.connectionMaxIdleTime(Duration.ofMillis(connectionMaxIdleTime));
         }
         SqsClientBuilder sqsClientBuilder = SqsClient.builder().region(Region.of(connectionConfig.getRegion())).
                 httpClient(apacheHttpClientBuilder.build());
@@ -96,11 +96,11 @@ public class SqsConnection implements Connection {
                     create(awsAccessKeyId, awsSecretAccessKey));
         }
         if (apiCallTimeout != -1) {
-            sqsClientBuilder.overrideConfiguration(b -> b.apiCallTimeout(Duration.ofSeconds(apiCallTimeout)));
+            sqsClientBuilder.overrideConfiguration(b -> b.apiCallTimeout(Duration.ofMillis(apiCallTimeout)));
         }
         if (apiCallAttemptTimeout != -1) {
             sqsClientBuilder.overrideConfiguration(b -> b.apiCallAttemptTimeout(
-                    Duration.ofSeconds(apiCallAttemptTimeout)));
+                    Duration.ofMillis(apiCallAttemptTimeout)));
         }
         return sqsClientBuilder.credentialsProvider(credentialsProvider).build();
     }

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/utils/Utils.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/utils/Utils.java
@@ -50,6 +50,7 @@ import software.amazon.awssdk.services.sqs.model.QueueAttributeName;
 import software.amazon.awssdk.services.sqs.model.SqsResponseMetadata;
 
 import javax.xml.stream.XMLStreamException;
+import java.math.BigDecimal;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
@@ -335,11 +336,22 @@ public class Utils {
             throws NumberFormatException {
         AwsRequestOverrideConfiguration.Builder overrideConfiguration = AwsRequestOverrideConfiguration.builder();
         if (StringUtils.isNotBlank(apiCallTimeout)) {
-            overrideConfiguration.apiCallTimeout(Duration.ofSeconds(Integer.parseInt(apiCallTimeout)));
+            overrideConfiguration.apiCallTimeout(Duration.ofMillis(convertToMillis(apiCallTimeout)));
         }
         if (StringUtils.isNotBlank(apiCallAttemptTimeout)) {
-            overrideConfiguration.apiCallAttemptTimeout(Duration.ofSeconds(Integer.parseInt(apiCallAttemptTimeout)));
+            overrideConfiguration.apiCallAttemptTimeout(Duration.ofMillis(convertToMillis(apiCallAttemptTimeout)));
         }
         return overrideConfiguration;
+    }
+
+    /**
+     * Convert given duration in seconds to milliseconds
+     *
+     * @param duration - duration in seconds
+     * @return integer
+     */
+    public static Integer convertToMillis(String duration) {
+        double seconds = Double.parseDouble(duration);
+        return (int) (seconds * 1000);
     }
 }


### PR DESCRIPTION
## Purpose
> This change allows time configuration values to be provided in milliseconds, with support for specifying the time in decimal seconds 

Fixes:https://github.com/wso2/micro-integrator/issues/3690

## Goals
> To allow definition of time out configs in milliseconds.

## Approach
> This change allows time configuration values to be provided in milliseconds by supporting for specifying them in decimal format (e.g., 1500 milliseconds can be expressed as 1.5 seconds). This offers more flexibility when configuring time durations. This approach was designed considering the backward compatibility. Any value defined in seconds will be converted to milliseconds and used in backend. No changes are required for current setups, ensuring seamless transition to the new format.