### PR TITLE
Add option to configure custom SQS endpoint

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/config/Init.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/config/Init.java
@@ -81,6 +81,8 @@ public class Init extends AbstractConnector implements ManagedLifecycle {
                 lookupTemplateParamater(msgContext, Constants.AWS_ACCESS_KEY_ID);
         String awsSecretAccessKey = (String) ConnectorUtils.
                 lookupTemplateParamater(msgContext, Constants.AWS_SECRET_ACCESS_KEY);
+        String endpoint = (String) ConnectorUtils.
+                lookupTemplateParamater(msgContext, Constants.ENDPOINT);
         String socketTimeout = (String) ConnectorUtils.lookupTemplateParamater(msgContext, Constants.SOCKET_TIMEOUT);
         String connectionAcquisitionTimeout = (String) ConnectorUtils.lookupTemplateParamater(msgContext,
                 Constants.CONNECTION_ACQUISITION_TIMEOUT);
@@ -100,6 +102,9 @@ public class Init extends AbstractConnector implements ManagedLifecycle {
         connectionConfig.setRegion(region);
         connectionConfig.setAwsAccessKeyId(awsAccessKeyId);
         connectionConfig.setAwsSecretAccessKey(awsSecretAccessKey);
+        if (StringUtils.isNotBlank(endpoint)) {
+            connectionConfig.setEndpoint(endpoint);
+        }
         if (StringUtils.isNotBlank(socketTimeout)) {
             connectionConfig.setSocketTimeout(Utils.convertToMillis(socketTimeout));
         }

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/connection/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/connection/ConnectionConfiguration.java
@@ -27,6 +27,7 @@ public class ConnectionConfiguration {
     public String region;
     private String awsAccessKeyId;
     private String awsSecretAccessKey;
+    private String endpoint;
 
     private String connectionName;
     private Integer connectionAcquisitionTimeout = -1;
@@ -76,6 +77,14 @@ public class ConnectionConfiguration {
 
     public void setAwsSecretAccessKey(String awsSecretAccessKey) {
         this.awsSecretAccessKey = awsSecretAccessKey;
+    }
+
+    public String getEndpoint() {
+        return this.endpoint;
+    }
+
+    public void setEndpoint(String endpoint) {
+        this.endpoint = endpoint;
     }
 
     public Integer getConnectionAcquisitionTimeout() {
@@ -141,6 +150,7 @@ public class ConnectionConfiguration {
                     StringUtils.equals(this.region, connectionConfiguration.getRegion()) &&
                     StringUtils.equals(this.awsAccessKeyId, connectionConfiguration.getAwsAccessKeyId()) &&
                     StringUtils.equals(this.awsSecretAccessKey, connectionConfiguration.getAwsSecretAccessKey()) &&
+                    StringUtils.equals(this.endpoint, connectionConfiguration.getEndpoint()) &&
                     StringUtils.equals(this.connectionTimeout.toString(), connectionConfiguration.
                             getConnectionTimeout().toString()) &&
                     StringUtils.equals(this.socketTimeout.toString(), connectionConfiguration.getSocketTimeout().

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/connection/SqsConnection.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/connection/SqsConnection.java
@@ -29,6 +29,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.SqsClientBuilder;
 
+import java.net.URI;
 import java.time.Duration;
 
 /**
@@ -90,6 +91,10 @@ public class SqsConnection implements Connection {
         }
         SqsClientBuilder sqsClientBuilder = SqsClient.builder().region(Region.of(connectionConfig.getRegion())).
                 httpClient(apacheHttpClientBuilder.build());
+        String endpoint = connectionConfig.getEndpoint();
+        if (StringUtils.isNotBlank(endpoint)) {
+            sqsClientBuilder.endpointOverride(URI.create(endpoint));
+        }
         AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
         if (StringUtils.isNotBlank(awsAccessKeyId) && StringUtils.isNotBlank(awsSecretAccessKey)) {
             credentialsProvider = StaticCredentialsProvider.create(AwsBasicCredentials.

--- a/src/main/java/org/wso2/carbon/connector/amazonsqs/constants/Constants.java
+++ b/src/main/java/org/wso2/carbon/connector/amazonsqs/constants/Constants.java
@@ -63,6 +63,11 @@ public class Constants {
     public static final String AWS_SECRET_ACCESS_KEY = "secretAccessKey";
 
     /**
+     * Constant for optional endpoint override (e.g. VPC interface endpoint or custom proxy URL).
+     */
+    public static final String ENDPOINT = "endpoint";
+
+    /**
      * Constant for client exception msg.
      */
     public static final String CLIENT_EXCEPTION_MSG = "Error occurred while generating the client: ";

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -22,6 +22,9 @@
     <parameter name="accessKeyId"
                description="The access key ID that corresponds to the secret access key that you used to sign the request"/>
     <parameter name="secretAccessKey" description="The secret access key"/>
+    <parameter name="endpoint" description="Optional custom endpoint URL. Use this for VPC interface endpoints or
+     private/custom SQS-compatible hosts (for example: https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com).
+     Leave blank to use the default AWS endpoint for the selected region."/>
     <parameter name="connectionMaxIdleTime" description="The maximum amount of time(In Seconds) that a connection should be
                 allowed to remain open while idle"/>
     <parameter name="connectionTimeout" description="The amount of time(In Seconds) to wait when initially establishing

--- a/src/main/resources/uischema/connection.json
+++ b/src/main/resources/uischema/connection.json
@@ -78,6 +78,17 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "endpoint",
+                    "displayName": "Custom Endpoint URL",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Optional custom endpoint URL. Use this for VPC interface endpoints or private/custom SQS-compatible hosts (for example: https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com). Leave blank to use the default AWS endpoint for the selected region."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "connectionMaxIdleTime",
                     "displayName": "Connection Max Idle Time",
                     "inputType": "integerOrExpression",


### PR DESCRIPTION
## Purpose

Add option to configure custom SQS endpoint.

The `endpoint` parameter in the connection definition can be used to configure an optional custom endpoint URL. This can be used for VPC interface endpoints or private/custom SQS-compatible hosts (for example: https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com). Leave this blank to use the default AWS endpoint for the selected region.

```xml
<amazonsqs.init>
  <connectionType>AMAZONSQS</connectionType>
  <region>us-east-2</region>
  <accessKeyId>xxxx</accessKeyId>
  <secretAccessKey>xxxx</secretAccessKey>
  <endpoint>https://vpce-xxxx.sqs.us-east-1.vpce.amazonaws.com</endpoint>
  <name>SQS_VPC</name>
</amazonsqs.init>
```

Fixes: https://github.com/wso2/product-integrator-mi/issues/4886